### PR TITLE
Integrate Brainrot_exportV5 game into tracer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,13 @@ plugins {
 
 android {
     namespace = "com.example.launcher"
-    compileSdk = 34
+    // Align with Unity export which targets 35
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "com.example.launcher"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 
@@ -29,6 +30,7 @@ android {
     }
 
     compileOptions {
+        // Unity library compiles with Java 11; keep Kotlin 17 for app
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -75,6 +77,9 @@ dependencies {
     
     // Lottie for animations
     implementation("com.airbnb.android:lottie:6.2.0")
+
+    // Unity exported Android library
+    implementation(project(":unityLibrary"))
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,13 @@
         android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
 
         <activity android:name=".GameActivity" />
+        <!-- Ensure Unity activity does not create another launcher icon -->
+        <activity
+            android:name="com.unity3d.player.UnityPlayerActivity"
+            android:exported="false"
+            tools:node="merge">
+            <intent-filter tools:node="removeAll" />
+        </activity>
         <activity 
             android:name=".MainActivity"
             android:theme="@style/Theme.ArcLauncher.Launcher"

--- a/app/src/main/java/com/example/launcher/OnboardingActivity.kt
+++ b/app/src/main/java/com/example/launcher/OnboardingActivity.kt
@@ -91,12 +91,12 @@ class OnboardingActivity : ComponentActivity() {
             )
             4 -> AppTracerScreen2(
                 onContinueClick = {
-                    continueOnboardingAfterPermission = false
-                    requestSetDefaultLauncher()
+                    // After App Tracer 2, launch the Unity game
+                    launchGame()
                 },
                 onSkipClick = {
-                    continueOnboardingAfterPermission = false
-                    requestSetDefaultLauncher()
+                    // Directly launch the Unity game
+                    launchGame()
                 }
             )
         }
@@ -148,6 +148,18 @@ class OnboardingActivity : ComponentActivity() {
             } catch (e: Exception) {
                 requestRuntimePermissions()
             }
+        }
+    }
+
+    private fun launchGame() {
+        try {
+            val intent = Intent(this, com.unity3d.player.UnityPlayerActivity::class.java)
+            startActivity(intent)
+            finish()
+        } catch (e: Exception) {
+            // Fallback to placeholder GameActivity if Unity activity is unavailable
+            startActivity(Intent(this, GameActivity::class.java))
+            finish()
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,8 +16,23 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // Provide local AARs from the Unity export
+        flatDir {
+            dirs(file("Brainrot_exportV5/unityLibrary/libs"))
+        }
     }
 }
 
 rootProject.name = "Launcher"
 include(":app")
+// Include Unity export modules
+include(":unityLibrary")
+include(":unityLibrary:FirebaseApp.androidlib")
+include(":unityLibrary:GoogleMobileAdsPlugin.androidlib")
+
+// Point included modules to the Unity export locations
+project(":unityLibrary").projectDir = file("Brainrot_exportV5/unityLibrary")
+project(":unityLibrary:FirebaseApp.androidlib").projectDir =
+    file("Brainrot_exportV5/unityLibrary/FirebaseApp.androidlib")
+project(":unityLibrary:GoogleMobileAdsPlugin.androidlib").projectDir =
+    file("Brainrot_exportV5/unityLibrary/GoogleMobileAdsPlugin.androidlib")


### PR DESCRIPTION
Integrate the `Brainrot_exportV5` Unity game module and launch it after `AppTracerScreen2`.

This PR integrates the `Brainrot_exportV5` Unity game by including its modules in Gradle, aligning SDK versions, ensuring `UnityPlayerActivity` doesn't create a duplicate launcher icon, and wiring `AppTracerScreen2`'s continue/skip actions to launch the game.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6a9b351-45af-4059-8cfd-0efecbbea32c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6a9b351-45af-4059-8cfd-0efecbbea32c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

