### PR TITLE
Fix unitylibrary build gradle error

### DIFF
--- a/Brainrot_exportV5/launcher/build.gradle
+++ b/Brainrot_exportV5/launcher/build.gradle
@@ -28,7 +28,9 @@ android {
     }
 
     aaptOptions {
-        noCompress = ['.unity3d', '.ress', '.resource', '.obb', '.bundle', '.unityexp'] + unityStreamingAssets.tokenize(', ')
+        def streamingAssets = (project.findProperty('unityStreamingAssets') ?: '').toString()
+        def extraNoCompress = streamingAssets ? streamingAssets.tokenize(',').collect { it.trim() } : []
+        noCompress = ['.unity3d', '.ress', '.resource', '.obb', '.bundle', '.unityexp'] + extraNoCompress
         ignoreAssetsPattern = "!.svn:!.git:!.ds_store:!*.scc:!CVS:!thumbs.db:!picasa.ini:!*~"
     }
 

--- a/Brainrot_exportV5/unityLibrary/build.gradle
+++ b/Brainrot_exportV5/unityLibrary/build.gradle
@@ -75,7 +75,9 @@ android {
     }
 
     aaptOptions {
-        noCompress = ['.unity3d', '.ress', '.resource', '.obb', '.bundle', '.unityexp'] + unityStreamingAssets.tokenize(', ')
+        def streamingAssets = (project.findProperty('unityStreamingAssets') ?: '').toString()
+        def extraNoCompress = streamingAssets ? streamingAssets.tokenize(',').collect { it.trim() } : []
+        noCompress = ['.unity3d', '.ress', '.resource', '.obb', '.bundle', '.unityexp'] + extraNoCompress
         ignoreAssetsPattern = "!.svn:!.git:!.ds_store:!*.scc:!CVS:!thumbs.db:!picasa.ini:!*~"
     }
 


### PR DESCRIPTION
Fix `MissingPropertyException` by reading `unityStreamingAssets` as a project property in `aaptOptions`.

The original `build.gradle` scripts attempted to access `unityStreamingAssets` directly within the `aaptOptions` block, causing a `groovy.lang.MissingPropertyException`. This was because `aaptOptions` (an `LibraryAndroidResourcesImpl$AgpDecorated` object) does not have such a property. The fix uses `project.findProperty('unityStreamingAssets')` to correctly retrieve this value from the project's properties, preventing the error and ensuring `noCompress` is populated safely.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6cdf440-702f-4e50-834f-1bd6ab5e7514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e6cdf440-702f-4e50-834f-1bd6ab5e7514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

