### PR TITLE
Changes from background agent bc-950cc698-fdc0-4aca-ab0d-1838a85244ef

### DIFF
--- a/Brainrot_exportV5/gradle.properties
+++ b/Brainrot_exportV5/gradle.properties
@@ -9,7 +9,8 @@ unityTemplateVersion=7
 android.useAndroidX=true
 android.enableJetifier=true
 org.gradle.welcome=never
-android.aapt2FromMavenOverride=C\:\\Program Files\\Unity Hub\\Editor\\2022.3.50f1\\Editor\\Data\\PlaybackEngines\\AndroidPlayer\\SDK\\build-tools\\34.0.0\\aapt2.exe
+# Set a known-good NDK version to satisfy IL2CPP Gradle task
+android.ndkVersion=23.2.8568313
 
 
 android.jetifier.ignorelist=annotation-experimental-1.4.0.aar

--- a/Brainrot_exportV5/launcher/build.gradle
+++ b/Brainrot_exportV5/launcher/build.gradle
@@ -6,10 +6,11 @@ dependencies {
 
 android {
     namespace "com.all.steal.lemolio"
-    ndkPath "C:/Program Files/Unity Hub/Editor/2022.3.50f1/Editor/Data/PlaybackEngines/AndroidPlayer/NDK"
+    // Prefer ndkVersion in gradle.properties/local.properties; remove hardcoded path
 
     compileSdkVersion 35
-    buildToolsVersion '34.0.0'
+    ndkVersion "23.2.8568313"
+    // Use AGP default build tools; remove explicit version
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/Brainrot_exportV5/unityLibrary/FirebaseApp.androidlib/build.gradle
+++ b/Brainrot_exportV5/unityLibrary/FirebaseApp.androidlib/build.gradle
@@ -18,7 +18,7 @@ android {
     }
 
     compileSdkVersion 35
-    buildToolsVersion '34.0.0'
+    // Use AGP default build tools; remove explicit version to silence warning
     defaultConfig {
         minSdkVersion 24
         targetSdkVersion 31

--- a/Brainrot_exportV5/unityLibrary/build.gradle
+++ b/Brainrot_exportV5/unityLibrary/build.gradle
@@ -26,7 +26,13 @@ dependencies {
     // implementation(name: 'firebase-config-unity-11.6.0', ext:'aar') // add if present in libs
     implementation 'com.reyun.solar.engine.oversea:solar-engine-core:+' // Assets/SolarEngineNet/Android/Editor/Dependencies.xml:8
     implementation 'com.reyun.solar.engine.oversea:solar-remote-config:+' // Assets/SolarEngineNet/SolarEnginePlugins/RemoteConfigSDK/Android/Editor/Dependencies.xml:4
-    implementation 'com.singular.sdk:singular_sdk:12.9.1' // Packages/singular-unity-package/SingularSDK/Editor/SingularSDKDependencies.xml:7
+    // Singular SDK: prefer local AAR if present, otherwise resolve from Maven
+    def singularLocalAars = fileTree(dir: 'libs', include: ['singular_sdk-*.aar', 'singular_sdk.aar']).files
+    if (!singularLocalAars.isEmpty()) {
+        singularLocalAars.each { f -> implementation files(f) }
+    } else {
+        implementation 'com.singular.sdk:singular_sdk:12.+'
+    }
     implementation 'com.unity3d.ads:unity-ads:4.16.1' // Packages/com.google.ads.mobile.mediation.unity/source/plugin/Assets/GoogleMobileAds/Mediation/UnityAds/Editor/UnityMediationDependencies.xml:33
 // Android Resolver Dependencies End
     implementation(name: 'IngameDebugConsole', ext:'aar')
@@ -53,6 +59,7 @@ android {
     // ndkPath provided by local.properties (sdk.dir/ndk.dir). Remove hardcoded path.
     compileSdkVersion 35
     // Use AGP default build tools; explicit buildToolsVersion removed
+    ndkVersion "23.2.8568313"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
@@ -112,6 +119,7 @@ def BuildIl2Cpp(String workingDir, String configuration, String architecture, St
     commandLineArgs.add("--data-folder=" + workingDir + "/src/main/Il2CppOutputProject/Source/il2cppOutput/data")
     commandLineArgs.add("--generatedcppdir=" + workingDir + "/src/main/Il2CppOutputProject/Source/il2cppOutput")
     commandLineArgs.add("--cachedirectory=" + workingDir + "/build/il2cpp_"+ abi + "_" + configuration + "/il2cpp_cache")
+    // Use configured ndkVersion; android.ndkDirectory is provided by AGP when NDK is installed
     commandLineArgs.add("--tool-chain-path=" + android.ndkDirectory)
     staticLibraries.eachWithIndex {fileName, i->
         commandLineArgs.add("--additional-libraries=" + workingDir + "/src/main/jniStaticLibs/" + abi + "/" + fileName)
@@ -153,4 +161,4 @@ android {
 
 
 
-apply from: 'GoogleMobileAdsPlugin.androidlib\\packaging_options.gradle'
+apply from: 'GoogleMobileAdsPlugin.androidlib/packaging_options.gradle'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,9 @@ dependencyResolutionManagement {
         mavenCentral()
         maven { url = uri("https://artifact.bytedance.com/repository/pangle/") }
         maven { url = uri("https://dl-maven-android.mintegral.com/repository/mbridge_android_sdk_oversea") }
-        maven { url = uri("https://maven.singular.net/repository/maven/releases") }
+    // Singular Maven repositories (correct Nexus paths)
+    maven { url = uri("https://maven.singular.net/repository/maven-public") }
+    maven { url = uri("https://maven.singular.net/repository/maven-releases") }
         maven { url = uri("https://maven-android.solar-engine.com/repository/se_sdk_for_android/") }
         // Provide local AARs from the Unity export
         flatDir {


### PR DESCRIPTION
Fix Gradle build failures by correcting Singular SDK dependency resolution and NDK configuration.

The build was failing due to `ModuleVersionNotFoundException` for `com.singular.sdk:singular_sdk:12.9.1` and `InvalidUserDataException: NDK is not installed` for the `BuildIl2CppTask`. This PR updates Gradle repositories for Singular, adjusts the Singular dependency to support local AARs or a flexible Maven version, and correctly configures the NDK version for Unity's IL2CPP build. It also removes an unnecessary `buildToolsVersion` declaration.

---
<a href="https://cursor.com/background-agent?bcId=bc-950cc698-fdc0-4aca-ab0d-1838a85244ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-950cc698-fdc0-4aca-ab0d-1838a85244ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

